### PR TITLE
2 doc updates

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -134,7 +134,15 @@ functionGlobalContext
 
   can be accessed in a function node as:
 
-      context.global.os
+      global.get('osModule')
+
+<div class="doc-callout"><em>Note</em>: Prior to Node-RED v0.13, the documented
+way to use global context was to access it as a sub-property of <code>context</code>:
+<pre>context.global.foo = "bar";
+var osModule = context.global.osModule;</pre>
+This method is still supported, but deprecated in favour of the <code>global.get</code>/<code>global.set</code>
+functions. This is in anticipation of being able to persist the context data in a future release.
+</div>
 
 debugMaxLength
 : Debug Nodes - the maximum length, in characters, of any message sent to the

--- a/docs/writing-functions.md
+++ b/docs/writing-functions.md
@@ -74,7 +74,7 @@ a message containing the payload length is passed to the second output:
 
 {% highlight javascript %}
 var newMsg = { payload: msg.payload.length };
-return [[msg], [newMsg]];
+return [msg, newMsg];
 {% endhighlight %}
 
 #### Multiple Messages

--- a/docs/writing-functions.md
+++ b/docs/writing-functions.md
@@ -74,7 +74,7 @@ a message containing the payload length is passed to the second output:
 
 {% highlight javascript %}
 var newMsg = { payload: msg.payload.length };
-return [msg, newMsg];
+return [[msg], [newMsg]];
 {% endhighlight %}
 
 #### Multiple Messages


### PR DESCRIPTION
Update the context access doc in the configuration.md

Fix the multiple output section of the Function doc (prompted by http://stackoverflow.com/questions/38529133/return-one-message-for-each-output-on-node-red-function-block/)
