### PR TITLE
Double Icon Size

### DIFF
--- a/docs/creating-nodes/appearance.md
+++ b/docs/creating-nodes/appearance.md
@@ -71,7 +71,7 @@ A node can provide its own icon in a directory called `icons` alongside its `.js
 and `.html` files. These directories get added to the search path when the editor
 looks for a given icon filename. Because of this, the icon filename must be unique.
 
-The icon should be white on a transparent background, 20 x 30 in size.
+The icon should be white on a transparent background, 40 x 60 in size.
 
 ### Background Colour
 


### PR DESCRIPTION
I suggest to double the recommended icon size, 20x30 leads to a blurry look on HiDPI (e.g. Apple Retina) displays. With 40x60 they stay sharp on 2x image rendering.