### PR TITLE
Add snap installation instructions

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -4,6 +4,14 @@ toc: getting-started-toc.html
 title: Installation
 ---
 
+### Install on Linux
+
+Install Node-RED in seconds on [Ubuntu and other snap supported Linux distributions](https://snapcraft.io/docs/core/install) with:
+
+    snap install node-red--beta
+
+Installing a snap is very quick. Snaps are secure. They are isolated with all of their dependencies. Snaps also auto update when a new version is released.
+
 ### Install node.js
 
 We recommend the use of node.js LTS 6.x or 6.x . Node-RED no longer supports node.js 0.10.x or 0.12.x.


### PR DESCRIPTION
This pull request adds installation instructions for users of [snap enabled Linux distributions](https://snapcraft.io/docs/core/install). Snaps enable ISVs and projects to make their software available to millions of Linux users via the snap store and directly control delivery of software updates to their users. Snaps of stable desktop applications will also be available via the desktop Software Center, improving the discoverability of your software. Your software can be installed with a simple `snap install node-red --beta` simplifying the installation instructions for your users. Once the snap is released into the stable channel in the store, users no longer need to add the `--beta`.