### PR TITLE
Add documentation for EditableList method addItems

### DIFF
--- a/docs/api/ui/editableList/index.md
+++ b/docs/api/ui/editableList/index.md
@@ -31,6 +31,7 @@ own right. Used by the core `Switch` and `Change` nodes.
         <h3>Methods</h3>
         <table>
             <tr><td><a href="#methods-addItem">addItem</a></td></tr>
+            <tr><td><a href="#methods-addItems">addItem</a></td></tr>
             <tr><td><a href="#methods-removeItem">removeItem</a></td></tr>
             <tr><td><a href="#methods-width">width</a></td></tr>
             <tr><td><a href="#methods-height">height</a></td></tr>
@@ -269,6 +270,14 @@ Adds an item to the end of the list. `itemData` is an object that will be associ
 with the item in the list.
 
     $("ol.list").editableList('addItem',{fruit:"banana"});
+
+#### <a href="#methods-addItems" name="methods-addItem">addItem( itemData )</a>
+
+Adds items contained in an array to the end of the list. `itemData` is an array of objects that will be associated
+with the item in the list.
+
+    $("ol.list").editableList('addItem',[{fruit:"banana"},{fruit:"apple"},{fruit:"pear"});
+
 
 #### <a href="#methods-removeItem" name="methods-removeItem">removeItem( itemData )</a>
 

--- a/docs/api/ui/editableList/index.md
+++ b/docs/api/ui/editableList/index.md
@@ -15,6 +15,7 @@ own right. Used by the core `Switch` and `Change` nodes.
             <tr><td><a href="#options-addButton">addButton</a></td></tr>
             <tr><td><a href="#options-addItem">addItem</a></td></tr>
             <tr><td><a href="#options-connectWith">connectWith</a></td></tr>
+            <tr><td><a href="#options-header">header</a></td></tr>
             <tr><td><a href="#options-height">height</a></td></tr>
             <tr><td><a href="#options-filter">filter</a></td></tr>
             <tr><td><a href="#options-resize">resize</a></td></tr>
@@ -98,12 +99,21 @@ dragged from this list to any other jQuery `sortable` list, such as another `edi
         connectWith: ".my-other-list"
     });
 
+#### <a href="#options-header" name="options-header">header</a>
+
+<span class="method-return">Type: DOM/JQuery object</span>
+
+Inserts the DOM/JQuery object as a header for the list.
+
+    $("ol.list").editableList({
+        header: $("<div>").append($.parseHTML("<div style='width:40%; display: inline-grid'>Name</div><div style='display: inline-grid'>Type</div>")),
+    });
 
 #### <a href="#options-height" name="options-height">height</a>
 
 <span class="method-return">Type: String|Number</span>
 
-Sets the height of the list including, if enabled, its add button.
+Sets the height of the list including, if enabled, its add button.  Setting height to 'auto' removes the vertical scrollbar and displays the list at the full height needed to contain the contents.
 
     $("ol.list").editableList({
         height: 300

--- a/docs/api/ui/editableList/index.md
+++ b/docs/api/ui/editableList/index.md
@@ -271,12 +271,12 @@ with the item in the list.
 
     $("ol.list").editableList('addItem',{fruit:"banana"});
 
-#### <a href="#methods-addItems" name="methods-addItems">addItem( itemData )</a>
+#### <a href="#methods-addItems" name="methods-addItems">addItems( itemData )</a>
 
 Adds items contained in an array to the end of the list. `itemData` is an array of objects that will be associated
 with the item in the list.
 
-    $("ol.list").editableList('addItem',[{fruit:"banana"},{fruit:"apple"},{fruit:"pear"});
+    $("ol.list").editableList('addItem',[{fruit:"banana"},{fruit:"apple"},{fruit:"pear"}]);
 
 
 #### <a href="#methods-removeItem" name="methods-removeItem">removeItem( itemData )</a>

--- a/docs/api/ui/editableList/index.md
+++ b/docs/api/ui/editableList/index.md
@@ -31,7 +31,7 @@ own right. Used by the core `Switch` and `Change` nodes.
         <h3>Methods</h3>
         <table>
             <tr><td><a href="#methods-addItem">addItem</a></td></tr>
-            <tr><td><a href="#methods-addItems">addItem</a></td></tr>
+            <tr><td><a href="#methods-addItems">addItems</a></td></tr>
             <tr><td><a href="#methods-removeItem">removeItem</a></td></tr>
             <tr><td><a href="#methods-width">width</a></td></tr>
             <tr><td><a href="#methods-height">height</a></td></tr>
@@ -271,7 +271,7 @@ with the item in the list.
 
     $("ol.list").editableList('addItem',{fruit:"banana"});
 
-#### <a href="#methods-addItems" name="methods-addItem">addItem( itemData )</a>
+#### <a href="#methods-addItems" name="methods-addItems">addItem( itemData )</a>
 
 Adds items contained in an array to the end of the list. `itemData` is an array of objects that will be associated
 with the item in the list.

--- a/docs/creating-nodes/config-nodes.md
+++ b/docs/creating-nodes/config-nodes.md
@@ -102,7 +102,7 @@ module.exports = function(RED) {
         if (this.server) {
             // Do something with:
             //  this.server.host
-            //  this.server.post
+            //  this.server.port
         } else {
             // No config node configured
         }

--- a/docs/creating-nodes/help-style-guide.md
+++ b/docs/creating-nodes/help-style-guide.md
@@ -26,25 +26,6 @@ a consistent appearance between nodes.
 </div>
 <div class="grid" style="min-height:auto; padding:5px 0 5px; border-bottom: 1px solid #f0f0f0;">
     <div class="col-1-2">
-        If the node has any configuration properties, this section describes those properties
-        and how they affect the operation of the node.  The description should be brief - if further 
-        descrption is needed, it should be in the Details section.
-    </div>
-    <div class="col-1-2 node-help" style="padding-right: 5px; background: #f9f9f9;">
-        <h3>Properties</h3>
-           <dl class="message-properties">
-              <dt>server
-                  <span class="property-type">config node</span>
-              </dt>
-              <dd> the config node specifying the MQTT server to connect to. </dd>
-              <dt class="optional">topic <span class="property-type">string</span></dt>
-              <dd> the MQTT topic to publish to.</dd>
-         </dl>
-     </div>
-</div>
-    
-<div class="grid" style="min-height:auto; padding:5px 0 5px; border-bottom: 1px solid #f0f0f0;">
-    <div class="col-1-2">
         If the node has an input, this section describes the properties of the
         message the node will use. The expected type of each property can also
         be provided. The description should be brief - if further description is
@@ -130,16 +111,6 @@ The above example was created with the following HTML.
 <script type="text/x-red" data-help-name="node-type">
 <p>Connects to a MQTT broker and publishes messages.</p>
 
-<h3>Properties</h3>    
-    <dl class="message-properties">
-        <dt >server <span class="property-type">config node</span></dt>
-        <dd> the MQTT server to publish to.</dd>
-        <dt class="optional">topic <span class="property-type">string</span></dt>
-        <dd> the MQTT topic to publish to. Overrides <code>msg.topic</code></dd>
-        <dt class="optional">QoS <span class="property-type">string</span></dt>
-        <dd> 0, fire and forget - 1, at least once - 2, once and once only. Overrides <code>msg.qos</code></dd>
-    </dl>
-    
 <h3>Inputs</h3>
     <dl class="message-properties">
         <dt>payload


### PR DESCRIPTION
Undocumented features in code

header
height:auto
addItems

node-red/editor/js/ui/common/editableList.js

line 54:

            if (this.options.header) {
                this.options.header.addClass("red-ui-editableList-header");
                this.borderContainer = this.uiContainer.wrap("<div>").parent();
                this.borderContainer.prepend(this.options.header);
                this.topContainer = this.borderContainer.wrap("<div>").parent();
            } else {

line 119:

     if (this.options.height !== 'auto') {
                this.uiContainer.css("overflow-y","scroll");
                if (!isNaN(this.options.height)) {
                    this.uiHeight = this.options.height;
                }
            }


line 291:

    addItems: function(items) {
            for (var i=0; i<items.length;i++) {
                this.addItem(items[i]);
            }
        },