### PR TITLE
changed array to object in creating-nodes docs

### DIFF
--- a/docs/creating-nodes/properties.md
+++ b/docs/creating-nodes/properties.md
@@ -46,7 +46,7 @@ property called `prefix` to the node:
 
 ### Property definitions
 
-The entries in the `defaults` array can have the following attributes:
+The entries in the `defaults` object can have the following attributes:
 
 - `value` : (any type) the default value the property takes
 - `required` : (boolean) *optional* whether the property is required. If set to


### PR DESCRIPTION
It seems to be an object and not an array. Or am I missing something?