### PR TITLE
fix type of return value from editableList's items method

### DIFF
--- a/docs/api/ui/editableList/index.md
+++ b/docs/api/ui/editableList/index.md
@@ -314,11 +314,11 @@ Sets the height of the editableList. This must be used in place of the standard
 
 #### <a href="#methods-items" name="methods-items">items()</a>
 
-<span class="method-return">Type: Array</span>
+<span class="method-return">Type: jQuery Object</span>
 
-Gets an Array of all list items. Each item is the jQuery DOM element for the item.
+Gets a jQuery object containing all list items.
 
-Each element stores the original data for the item under property called `data`.
+Each element stores the *original* data for the item under a data property named `data`.
 
     var items = $("ol.list").editableList('items');
 


### PR DESCRIPTION
The value returned from `editableList('items')` is a jQuery object; not a vanilla `Array` containing jQuery or DOM objects.

It was also unclear from the documentation how to access the original data.  Short of adding an explicit example for this, I hope I clarified it.  In other words:

```js
$thing.editableList('items').each(function () {
  $(this).data('data'); // the original data
});
```

`data` is perhaps not the most *helpful* key name for this, but there it is.  :smile: