### PR TITLE
Change 'latest-v8' image tag to 'v8'

### DIFF
--- a/docs/platforms/docker.md
+++ b/docs/platforms/docker.md
@@ -26,7 +26,7 @@ the slim image with the missing packages.
 
 Additional images using a newer Node.js v8 base image are now available with the following tags.
 
-- **latest-v8** 
+- **v8**
 - **slim-v8**
 - **rpi-v8**
 


### PR DESCRIPTION
The image tag 'latest-v8' does not exist on DockerHub (as the image is tagged as 'v8'); and as such the documentation should reflect the correct tag