### PR TITLE
Fix docker tag latest-v8 -> v8

### DIFF
--- a/docs/platforms/docker.md
+++ b/docs/platforms/docker.md
@@ -26,7 +26,7 @@ the slim image with the missing packages.
 
 Additional images using a newer Node.js v8 base image are now available with the following tags.
 
-- **latest-v8** 
+- **v8** 
 - **slim-v8**
 - **rpi-v8**
 


### PR DESCRIPTION
Fix the docker latest-v8 tag to v8 to match the actual tags in the repo.