### PR TITLE
modify doc Installation for ver 0.20

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -77,7 +77,7 @@ you can use it. This must be done globally.
 You can then build and run the application
 
     grunt build
-    node red
+    npm start
 
 ### Next steps
 


### PR DESCRIPTION
https://nodered.org/docs/getting-started/installation

The command for starting Node-RED was changed with updating to ver 0.20.
I modified the command line of document "Installation".

```
grunt build
node red
```
↓
```
grunt build
npm start
```