### PR TITLE
Fix typo in the documentation for editableList

### DIFF
--- a/docs/api/ui/editableList/index.md
+++ b/docs/api/ui/editableList/index.md
@@ -317,7 +317,7 @@ Adds items contained in an array to the end of the list. `itemData` is an array 
 with the item in the list.
 
 ```javascript
-$("ol.list").editableList('addItem',[{fruit:"banana"},{fruit:"apple"},{fruit:"pear"}]);
+$("ol.list").editableList('addItems',[{fruit:"banana"},{fruit:"apple"},{fruit:"pear"}]);
 ```
 
 #### <a href="#methods-removeItem" name="methods-removeItem">removeItem( itemData )</a>


### PR DESCRIPTION
I found that there's a typo in the documentation for editableList. I modified the typo.