### PR TITLE
Line 189, corrected spelling of console

### DIFF
--- a/docs/api/ui/editableList/index.md
+++ b/docs/api/ui/editableList/index.md
@@ -186,7 +186,7 @@ This callback is invoked after the main [`resize`](#options-resize) callback is 
 $("ol.list").editableList({
     resizeItem: function(row,index) {
         var originalData = $(row).data('data');
-        consol.log("Resize the row for item:", originalData)
+        console.log("Resize the row for item:", originalData)
     }
 });
 ```


### PR DESCRIPTION
console was spelled as "consol".