### PR TITLE
Added a troubleshooting note to Property definitions

### DIFF
--- a/docs/creating-nodes/properties.md
+++ b/docs/creating-nodes/properties.md
@@ -47,7 +47,7 @@ property called `prefix` to the node:
 
 ### Property definitions
 
-The entries in the `defaults` object can have the following attributes:
+The entries in the `defaults` object must be objects and can have the following attributes:
 
 - `value` : (any type) the default value the property takes
 - `required` : (boolean) *optional* whether the property is required. If set to
@@ -56,14 +56,6 @@ The entries in the `defaults` object can have the following attributes:
   value of the property.
 - `type` : (string) *optional* if this property is a pointer to a
   [configuration node](config-nodes),  this identifies the type of the node.
-
-*Note:  Make sure each property of defaults is an object.
-        If, after you make a code change and restart your server, you notice the flow is empty, 
-        and that none of the nodes appear to respond to clicks, look in the console log.  You 
-        may see an error similar to the following,
-        ```Cannot use 'in' operator to search for 'required' in jquery```.
-        That could indicate that you used a string, or something else besides an object as a value 
-        for one of the properties in defaults.*
 
 ### Reserved property names
 

--- a/docs/creating-nodes/properties.md
+++ b/docs/creating-nodes/properties.md
@@ -57,6 +57,14 @@ The entries in the `defaults` object can have the following attributes:
 - `type` : (string) *optional* if this property is a pointer to a
   [configuration node](config-nodes),  this identifies the type of the node.
 
+*Note:  Make sure each property of defaults is an object.
+        If, after you make a code change and restart your server, you notice the flow is empty, 
+        and that none of the nodes appear to respond to clicks, look in the console log.  You 
+        may see an error similar to the following,
+        ```Cannot use 'in' operator to search for 'required' in jquery```.
+        That could indicate that you used a string, or something else besides an object as a value 
+        for one of the properties in defaults.*
+
 ### Reserved property names
 
 There are some reserved names for properties that must not be used. These are:


### PR DESCRIPTION
A gotcha, that caused me several hours of time, is forgetting to make each property of defaults an object.
If it's not an object, bad things happen and you end up with this error "Cannot use 'in' operator to search for 'required' in jquery" in the console.