### PR TITLE
Fix typo in creating nodes custom node settings documentation

### DIFF
--- a/docs/creating-nodes/node-js.md
+++ b/docs/creating-nodes/node-js.md
@@ -249,7 +249,7 @@ For example, if the node type `sample-node` wanted to expose a setting called
 `colour`, the setting name should be `sampleNodeColour`.
 
 Within the runtime, the node can then reference the setting as
-`RED.setting.sampleNodeColour`.
+`RED.settings.sampleNodeColour`.
 
 
 #### Exposing settings to the editor


### PR DESCRIPTION
This should be `settings` (plural) like in the "Exposing settings to the editor" section below