### PR TITLE
Update beaglebone with instructions on creating Buster eMMC flasher image

### DIFF
--- a/docs/getting-started/beaglebone.md
+++ b/docs/getting-started/beaglebone.md
@@ -20,7 +20,9 @@ Currently, Debian (10) Buster is only available as an SD card image. If flashing
     cmdline=init=/opt/scripts/tools/eMMC/init-eMMC-flasher-v3.sh
 
 should be uncommented in the /boot/uEnv.txt file. The image can then be flashed to the eMMC like any 'flasher' image on the
-BeagleBoard website.
+BeagleBoard website. To do this, insert the SD card with the BeagleBone powered off, hold down the S2 button and apply power.
+Once the LEDs start flashing, release the button. Flashing will take between 5 and 25 minutes. The BeagleBone will power down
+at the end of this process, the SD card can be removed, and the BeagleBone will now boot from the eMMC.
 
 All the 4GB images for BeagleBone boards already have Node-RED pre-installed and set to auto-start,
 so you can just boot and point your browser at your BeagleBone, port 1880.

--- a/docs/getting-started/beaglebone.md
+++ b/docs/getting-started/beaglebone.md
@@ -15,6 +15,13 @@ If you want the latest Node-RED 1.x then you need to use the Alpha Testing - Deb
 
     sudo apt update && sudo apt full-upgrade
 
+Currently, Debian (10) Buster is only available as an SD card image. If flashing the image to the eMMC is desired, the line
+
+    cmdline=init=/opt/scripts/tools/eMMC/init-eMMC-flasher-v3.sh
+
+should be uncommented in the /boot/uEnv.txt file. The image can then be flashed to the eMMC like any 'flasher' image on the
+BeagleBoard website.
+
 All the 4GB images for BeagleBone boards already have Node-RED pre-installed and set to auto-start,
 so you can just boot and point your browser at your BeagleBone, port 1880.
 


### PR DESCRIPTION
Debian (10) Buster is required for Node-Red 1.x to be installed with the bb-node-red-installer. The image is currently only available as an SD card IoT image, but there is a simple change that can be made to turn this into an eMMC flasher image: just uncommenting one line in a file in the boot directory.
Contribution discussed with dceejay