### PR TITLE
Add admin API docs for projects manipulation

### DIFF
--- a/docs/api/admin/methods/delete/projects/index.md
+++ b/docs/api/admin/methods/delete/projects/index.md
@@ -1,0 +1,39 @@
+---
+layout: docs-api
+toc: toc-api-admin.html
+title: DELETE /projects/:id
+slug:
+  - url: "/docs/api/admin"
+    label: "admin"
+  - url: "/docs/api/admin/methods"
+    label: "methods"
+  - delete project
+---
+
+Delete an individual project.
+
+Deleting an active project is an error.
+
+Requires permission: <code>projects.write</code>
+
+### Headers
+
+Header          | Value
+----------------|-------
+`Authorization` | `Bearer [token]` - if authentication is enabled
+
+### Arguments
+
+Path Component | Description
+---------------|------------
+`id`           | The id of the project
+
+### Response
+
+Status Code | Reason         | Response
+------------|----------------|------------
+`204`       | Success        | _none_
+`400`       | Bad request    | An [Error response](/docs/api/admin/errors).
+`401`       | Not authorized | _none_
+
+

--- a/docs/api/admin/methods/get/projects/index.md
+++ b/docs/api/admin/methods/get/projects/index.md
@@ -1,0 +1,37 @@
+---
+layout: docs-api
+toc: toc-api-admin.html
+title: GET /projects
+slug:
+  - url: "/docs/api/admin"
+    label: "admin"
+  - url: "/docs/api/admin/methods"
+    label: "methods"
+  - get projects
+---
+
+Get list of projects.
+
+Requires permission: <code>projects.read</code>
+
+### Headers
+
+Header                 | Value
+-----------------------|-------
+`Authorization`        | `Bearer [token]` - if authentication is enabled
+
+### Response
+
+Status Code | Reason              | Response
+------------|---------------------|--------------
+`200`       | Success             | An object with array of project names and active project name
+`400`        | Runtime error       | _none_
+`401`       | Not authorized      | _none_
+
+
+{% highlight json %}
+{
+  "projects": ["PJ00", "PJ01"],
+  "active": "PJ01"
+}
+{% endhighlight %}

--- a/docs/api/admin/methods/index.md
+++ b/docs/api/admin/methods/index.md
@@ -15,6 +15,9 @@ slug:
 [<span>POST</span>/auth/token](post/auth/token)             | Exchange credentials for access token
 [<span>POST</span>/auth/revoke](post/auth/revoke)           | Revoke an access token
 [<span>GET</span>/settings](get/settings)                   | Get the runtime settings
+[<span>GET</span>/projects](get/projects)                   | Get the list of projects
+[<span>POST</span>/projects](post/projects)                 | Create a project
+[<span>DELETE</span>/projects/:id](delete/projects)          | Delete an individual project
 [<span>GET</span>/flows](get/flows)                         | Get the active flow configuration
 [<span>POST</span>/flows](post/flows)                       | Set the active flow configuration
 [<span>POST</span>/flow](post/flow)                         | Add a flow to the active configuration

--- a/docs/api/admin/methods/post/projects/index.md
+++ b/docs/api/admin/methods/post/projects/index.md
@@ -1,0 +1,59 @@
+---
+layout: docs-api
+toc: toc-api-admin.html
+title: POST /projects
+slug:
+  - url: "/docs/api/admin"
+    label: "admin"
+  - url: "/docs/api/admin/methods"
+    label: "methods"
+  - add project
+---
+
+Add a new project.  The created project becomes active one.
+
+Requires permission: <code>projects.write</code>
+
+### Headers
+
+Header                     | Value
+---------------------------|----------
+`Authorization`            | `Bearer [token]` - if authentication is enabled
+`Content-type`             | `application/json`
+
+### Arguments
+
+The request body must be a single project configuration object.
+
+{% highlight json %}
+{
+  "name": "PJ00",
+  "summary": "Summary of PJ00",
+  "path": "path/to/project",
+  "files": {
+    flow: "flow.json"
+  }
+  "credentialSecret": false,
+  "git": {
+    "remotes": {
+      "origin": {
+        "username": "user",
+        "password": "pass"
+      }
+    }
+  }
+}
+{% endhighlight %}
+
+The configuration object must, at a minimum, include the `name`, `files`, and `path` property. `summary` and `credentialSecret` specify summary text and credential secret string (or `false` if encryption disabled).  If git service is used as backend of the project, `git`property represents git remote configuration information.
+
+### Response
+
+Status Code | Reason         | Response
+------------|----------------|--------------
+`204`       | Success        | _none_
+`400`       | Bad request    | An [Error response](/docs/api/admin/errors)
+
+Returns the configuration object of the project.
+
+


### PR DESCRIPTION
This PR adds documentation for some Project related http admin APIs (GET/POST/DELETE) for listing, creating, and deleting projects.