### PR TITLE
Change text/x-red to text/html in node html file

### DIFF
--- a/docs/creating-nodes/config-nodes.md
+++ b/docs/creating-nodes/config-nodes.md
@@ -34,7 +34,7 @@ key differences:
     });
 </script>
 
-<script type="text/x-red" data-template-name="remote-server">
+<script type="text/html" data-template-name="remote-server">
     <div class="form-row">
         <label for="node-config-input-host"><i class="icon-bookmark"></i> Host</label>
         <input type="text" id="node-config-input-host">

--- a/docs/creating-nodes/first-node.md
+++ b/docs/creating-nodes/first-node.md
@@ -125,14 +125,14 @@ For more information about the runtime part of the node, see [here](node-js).
     });
 </script>
 
-<script type="text/x-red" data-template-name="lower-case">
+<script type="text/html" data-template-name="lower-case">
     <div class="form-row">
         <label for="node-input-name"><i class="icon-tag"></i> Name</label>
         <input type="text" id="node-input-name" placeholder="Name">
     </div>
 </script>
 
-<script type="text/x-red" data-help-name="lower-case">
+<script type="text/html" data-help-name="lower-case">
     <p>A simple node that converts the message payloads into all lower-case characters</p>
 </script>
 ```

--- a/docs/creating-nodes/help-style-guide.md
+++ b/docs/creating-nodes/help-style-guide.md
@@ -109,7 +109,7 @@ a consistent appearance between nodes.
 The above example was created with the following HTML.
 
 ~~~~~html
-<script type="text/x-red" data-help-name="node-type">
+<script type="text/html" data-help-name="node-type">
 <p>Connects to a MQTT broker and publishes messages.</p>
 
 <h3>Inputs</h3>

--- a/docs/creating-nodes/node-html.md
+++ b/docs/creating-nodes/node-html.md
@@ -13,11 +13,11 @@ contains three distinct part, each wrapped in its own `<script>` tag:
    what icon to use. It is within a regular javascript script tag
 
 2. the edit template that defines the content of the edit dialog for the node.
-   It is defined in a script of type `text/x-red` with `data-template-name` set
+   It is defined in a script of type `text/html` with `data-template-name` set
    to the [type of the node](#node-type).
 
 3. the help text that gets displayed in the Info sidebar tab. It is defined in a
-   script of type `text/x-red` with `data-help-name` set to the
+   script of type `text/html` with `data-help-name` set to the
    [type of the node](#node-type).
 
 
@@ -80,7 +80,7 @@ editor. It is an object with the following properties:
 
 The edit template for a node describes the content of its edit dialog.
 
-    <script type="text/x-red" data-template-name="node-type">
+    <script type="text/html" data-template-name="node-type">
         <div class="form-row">
             <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
             <input type="text" id="node-input-name" placeholder="Name">
@@ -115,7 +115,7 @@ The content of the first `<p>` tag is used as the tooltip when hovering over
 nodes in the palette.
 
 ~~~~html
-<script type="text/x-red" data-help-name="node-type">
+<script type="text/html" data-help-name="node-type">
    <p>Some useful help text to introduce the node.</p>
    <h3>Outputs</h3>
        <dl class="message-properties">


### PR DESCRIPTION
To use HTML linters, I changed `type="text/x-red"` to  `type="text/html"` in document about how to create Node-RED nodes.