### PR TITLE
Fix paletteCategories order

### DIFF
--- a/docs/user-guide/runtime/configuration.md
+++ b/docs/user-guide/runtime/configuration.md
@@ -124,7 +124,7 @@ paletteCategories
   the list, the category will get added to the end of the palette. If not set,
   the following default order is used:
 
-      ['subflows', 'input', 'output', 'function', 'social', 'storage', 'analysis', 'advanced'],
+      ['subflows', 'common', 'function', 'network', 'sequence', 'parser', 'storage'],
 
    _Note_: Until the user creates a subflow the subflow category will be empty and will
    not be visible in the palette.


### PR DESCRIPTION
Fix paletteCategories order to match the order in the "Version 1.0 released" [blog post](https://nodered.org/blog/2019/09/30/version-1-0-released#reorganised-palette).