### PR TITLE
Fix typos in Flow Development Guide

### DIFF
--- a/docs/developing-flows/documenting-flows.md
+++ b/docs/developing-flows/documenting-flows.md
@@ -45,8 +45,8 @@ If there is a node that has more than one output port, aligning the branched flo
 When a flow gets too long, arranging some nodes vertically can be used to good effect. In the following figure, some of the nodes are arranged vertically to imply a relationship between them. It is easier to understand the nature of the overall flow if it is visually obvious what smaller sections it is comprised of and how they relate to each other.
 
 <div class="figure">
-    <img src="./images/node-vertical-arrangement.png" alt="Vertically aligning logical segements of a long flow"/>
-    <p class="caption">Vertically aligning logical segements of a long flow</p>
+    <img src="./images/node-vertical-arrangement.png" alt="Vertically aligning logical segments of a long flow"/>
+    <p class="caption">Vertically aligning logical segments of a long flow</p>
 </div>
 
 In some cases, these smaller sections may be candidates for moving to subflows that will reduce the visual complexity of the flow. That is particular true if that smaller section could be reused elsewhere in the flows.
@@ -65,7 +65,7 @@ Along with the label, nodes can also have a custom icon. For example, if you hav
 
 Choosing good names for things applies just as much to the tabs and subflows used.
 
-It also very important for Link nodes. Without a name set, you have to use the Link node's internal ID when creating links between different tabs. That makes it hard to identify the right target node and mistakes can happen. If you consider the Link nodes as providing APIs between the different tabs, then a good choice of naming scheme will be needed. The names should clearly identify the start and end point of each flow.
+It is also very important for Link nodes. Without a name set, you have to use the Link node's internal ID when creating links between different tabs. That makes it hard to identify the right target node and mistakes can happen. If you consider the Link nodes as providing APIs between the different tabs, then a good choice of naming scheme will be needed. The names should clearly identify the start and end point of each flow.
 
 ### Adding port labels
 

--- a/docs/developing-flows/flow-structure.md
+++ b/docs/developing-flows/flow-structure.md
@@ -56,7 +56,7 @@ Subflows appear as regular nodes so can be used at any point in a flow. However 
 
 When creating subflows, you may want to be able to customise their behaviour in some way. For example, changing what MQTT topic it publishes to.
 
-One pattern for doing that is by setting `msg.topic` on every message passed to the subflow. But that requires adding a Change node ange node in front of every subflow instance in order to set the desired value.
+One pattern for doing that is by setting `msg.topic` on every message passed to the subflow. But that requires adding a Change node in front of every subflow instance in order to set the desired value.
 
 An easier way for doing this is by using Subflow properties. These are properties that can be set on the subflow instance and appear as environment variables inside the subflow.
 

--- a/docs/developing-flows/message-design.md
+++ b/docs/developing-flows/message-design.md
@@ -15,7 +15,7 @@ For more information about messages in Node-RED you should read the [Working wit
 section of the user guide.
 
 This section looks at some of the choices you need to make when deciding how to
-stucture the messages in your flows.
+structure the messages in your flows.
 
 ### Working with `msg.payload`
 
@@ -31,7 +31,7 @@ For example, consider a flow that receives an id in the payload of an MQTT messa
   <p class="caption">MQTT to database query</p>
 </div>
 
-The database node will put its result in the payload of the message it sends - overwritting the original id value. If the flow needs to be able to reference that id value later on, it can use a Change node to copy the value to another property that will not get overwritten.
+The database node will put its result in the payload of the message it sends - overwriting the original id value. If the flow needs to be able to reference that id value later on, it can use a Change node to copy the value to another property that will not get overwritten.
 
 <div class="figure">
   <img src="images/mqtt-query-save-id.png" alt="Using a Change node to copy the payload to msg.id">


### PR DESCRIPTION
I fixed typos which I found while translating Flow Development Guide.