### PR TITLE
Fix typo

### DIFF
--- a/_posts/2019-09-30-version-1-0-released.md
+++ b/_posts/2019-09-30-version-1-0-released.md
@@ -29,7 +29,7 @@ but there's plenty to get you started.
 
 ---
 
- - [Asynchonous message passing](#asynchronous-message-passing)
+ - [Asynchronous message passing](#asynchronous-message-passing)
  - [Node Send API](#node-send-api)
  - [Cloning messages](#cloning-messages)
  - [Reorganised palette](#reorganised-palette)


### PR DESCRIPTION
While translating blog about Node-RED v1.0, I found that there is an incorrect spelling.