### PR TITLE
Remove old info about node labels having " in" and " out" stripped off

### DIFF
--- a/docs/creating-nodes/node-html.md
+++ b/docs/creating-nodes/node-html.md
@@ -43,11 +43,6 @@ The node type is used throughout the editor to identify the node. It must
 match the value used by the call to `RED.nodes.registerType` in the corresponding
 `.js` file.
 
-The type is also used as the label for the node in the palette. If the type ends
-with " in" or " out" this is stripped off label. For example, the "mqtt in" and
-"mqtt out" nodes are both labeled as "mqtt", with the display of the input and
-output ports providing the "in" or "out" context.
-
 #### Node definition
 
 The node definition contains all of the information about the node needed by the


### PR DESCRIPTION
This generic behavior was removed for "Reorganise nodes into new categories": https://github.com/node-red/node-red/commit/da6db24f9e584702c973c0845aa53bb0ef1e57b2#diff-a971d819871339d0287b6efe397059030d62e0b81090ead3af6225ef37e18c4cR184

Some nodes like MQTT and HTTP do simplify their labels once in a flow. For example, "mqtt in" is shown in the palette but becomes just "mqtt" when in a flow. But that's a function of those nodes, and not a generic function of the editor.

I also removed the "The type is also used as the label for the node in the palette" line since that appears to only be as a fallback in certain circumstances, and labels are covered in detail elsewhere.

