### PR TITLE
Add directory to theme JSON file

### DIFF
--- a/docs/api/ui/themes/index.md
+++ b/docs/api/ui/themes/index.md
@@ -200,7 +200,7 @@ separate file and use `require` to import it:
 ```javascript
 RED.plugins.registerPlugin("my-custom-theme", {
     monacoOptions: {
-      theme: require("my-custom-theme-monaco-theme.json"),
+      theme: require("./my-custom-theme-monaco-theme.json"),
     }
 })
 ```


### PR DESCRIPTION
The directory is required when using a JSON file for the Monaco theme.