### PR TITLE
Changed css delimiter to semi-colon

### DIFF
--- a/docs/api/ui/autoComplete/index.md
+++ b/docs/api/ui/autoComplete/index.md
@@ -185,7 +185,7 @@ $("#node-input-example3").autoComplete({
 
                 var el = $('<div/>',{style:"white-space:nowrap"});
                 $('<span/>').text(pre).appendTo(el);
-                $('<span/>',{style:"font-weight: bold, color:red"}).text(matchedVal).appendTo(el);
+                $('<span/>',{style:"font-weight: bold; color:red"}).text(matchedVal).appendTo(el);
                 $('<span/>').text(post).appendTo(el);
 
                 matches.push({


### PR DESCRIPTION
Minor itty-bitty thing: Copy-pasting the example did not produce a red highlight as the css delimiter was set to comma instead of semi-colon.