### PR TITLE
[docs] correct a typo

### DIFF
--- a/docs/user-guide/runtime/securing-node-red.md
+++ b/docs/user-guide/runtime/securing-node-red.md
@@ -64,7 +64,7 @@ https: function() {
         // ...
         resolve({
             key: key
-            cert: ccert
+            cert: cert
         })
     });
 }


### PR DESCRIPTION
hello, i find a typo in [securing-node-red](https://nodered.org/docs/user-guide/runtime/securing-node-red#enabling-https-access)

#### I think it's a typo below :
```js
https: function() {
    return new Promise((resolve, reject) => {
        var key, cert;
        // Do some work to obtain valid certificates
        // ...
        resolve({
            key: key
            cert: ccert    // * type
        })
    });
}
```

#### and then i correct a type:
```js
https: function() {
    return new Promise((resolve, reject) => {
        var key, cert;
        // Do some work to obtain valid certificates
        // ...
        resolve({
            key: key
            cert: cert    // * correct a type
        })
    });
}
```