### PR TITLE
docs: Getting started with FlowForge

### DIFF
--- a/docs/getting-started/flowforge.md
+++ b/docs/getting-started/flowforge.md
@@ -1,0 +1,16 @@
+---
+layout: docs-getting-started
+title: FlowForge Community Edition
+slug: flowforge
+toc: toc-user-guide.html
+redirect_from:
+  - /docs/platforms/flowforge
+---
+
+FlowForge offers a platform to collaborate on Node-RED projects and can be
+installed in a public cloud as well as on ones personal server or local machine.
+
+There's multiple ways to run FlowForge; locally, docker-based, or in Kubernetes.
+When evaluating if FlowForge is for you, we recommend starting with a
+[local install](https://flowforge.com/docs/install/local/).
+

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -117,3 +117,15 @@ such as a Raspberry Pi or in the cloud and follow the guides below.
     </div>
   </a>
 </div>
+
+<div class="post-preview">
+  <a href="flowforge">
+    <div class="post-header">
+      <img src="/images/platform-cloud.png">
+      <h2>FlowForge Community Edition</h2>
+    </div>
+    <div class="post-content">
+      Running a multi tenant Node-RED solution
+    </div>
+  </a>
+</div>

--- a/index.html
+++ b/index.html
@@ -110,6 +110,7 @@ layout: barebones
                     <li><a href="https://fred.sensetecnic.com/">SenseTecnic FRED</a></li>
                     <li><a href="/docs/platforms/aws">Amazon Web Services</a></li>
                     <li><a href="/docs/platforms/azure">Microsoft Azure</a></li>
+                    <li><a href="https://flowforge.com">FlowForge</a></li>
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
As a user one might either use the FlowForge Cloud offering, or install
FlowForge themselfs to scale and manage their Node-RED roll out.

This change mentions both options in the appropriate places.