### PR TITLE
docs: add API documentation for /diagnostics and /flows/state

### DIFF
--- a/docs/api/admin/methods/get/diagnostics/index.md
+++ b/docs/api/admin/methods/get/diagnostics/index.md
@@ -1,0 +1,143 @@
+---
+layout: docs-api
+toc: toc-api-admin.html
+title: GET /diagnostics
+slug:
+  - url: "/docs/api/admin"
+    label: "admin"
+  - url: "/docs/api/admin/methods"
+    label: "methods"
+  - get diagnostics
+---
+
+Get the runtime diagnostics. Note that runtime diagnostics are available only if
+`diagnostics` value is set to `enabled: true` in the `settings.js` file.
+
+
+Requires permission: <code>settings.read</code>
+
+### Headers
+
+Header | Value
+-------|-------
+`Authorization` | `Bearer [token]` - if authentication is enabled
+
+### Response
+
+Status Code | Reason         | Response
+------------|----------------|--------------
+`200`       | Success        | See example response body
+`401`       | Not authorized | _none_
+
+{% highlight json %}
+{
+  "report": "diagnostics",
+  "scope": "basic",
+  "time": {
+    "utc": "Mon, 23 Jan 2023 20:15:08 GMT",
+    "local": "1/23/2023, 8:15:08 PM"
+  },
+  "intl": {
+    "locale": "en-US",
+    "timeZone": "UTC"
+  },
+  "nodejs": {
+    "version": "v16.16.0",
+    "arch": "x64",
+    "platform": "linux",
+    "memoryUsage": {
+      "rss": 106336256,
+      "heapTotal": 36225024,
+      "heapUsed": 33527912,
+      "external": 1905248,
+      "arrayBuffers": 145556
+    }
+  },
+  "os": {
+    "containerised": true,
+    "wsl": false,
+    "totalmem": 32841064448,
+    "freemem": 28394344448,
+    "arch": "x64",
+    "loadavg": [
+      1,
+      1.01,
+      0.89
+    ],
+    "platform": "linux",
+    "release": "5.15.85-1-MANJARO",
+    "type": "Linux",
+    "uptime": 5554.97,
+    "version": "#1 SMP PREEMPT Wed Dec 21 21:15:06 UTC 2022"
+  },
+  "runtime": {
+    "version": "3.0.2",
+    "isStarted": true,
+    "flows": {
+      "state": "start",
+      "started": true
+    },
+    "modules": {
+      "node-red": "3.0.2"
+    },
+    "settings": {
+      "available": true,
+      "apiMaxLength": "UNSET",
+      "disableEditor": false,
+      "contextStorage": {},
+      "debugMaxLength": 1000,
+      "editorTheme": {
+        "palette": {},
+        "projects": {
+          "enabled": false,
+          "workflow": {
+            "mode": "manual"
+          }
+        },
+        "codeEditor": {
+          "lib": "ace",
+          "options": {
+            "theme": "vs"
+          }
+        }
+      },
+      "flowFile": "flows.json",
+      "mqttReconnectTime": 15000,
+      "serialReconnectTime": 15000,
+      "socketReconnectTime": "UNSET",
+      "socketTimeout": "UNSET",
+      "tcpMsgQueueSize": "UNSET",
+      "inboundWebSocketTimeout": "UNSET",
+      "runtimeState": {
+        "enabled": false,
+        "ui": false
+      },
+      "adminAuth": "SET",
+      "httpAdminRoot": "/",
+      "httpAdminCors": "UNSET",
+      "httpNodeAuth": "UNSET",
+      "httpNodeRoot": "/",
+      "httpNodeCors": "UNSET",
+      "httpStatic": "UNSET",
+      "httpStaticRoot": "UNSET",
+      "httpStaticCors": "UNSET",
+      "uiHost": "SET",
+      "uiPort": "SET",
+      "userDir": "SET",
+      "nodesDir": "UNSET"
+    }
+  }
+}
+{% endhighlight %}
+
+The response object contains the following fields:
+
+Field          | Description
+---------------|------------
+`intl`         | The internationalization (i8n) language for the node-red instance
+`nodejs`       | NodeJS version for underlying architecture / platform
+`os`           | Operating System information and statistics for current memory usage
+`runtime`      | Current Node-RED runtime information
+`modules`      | Node-RED modules and their respective versions
+`settings`     | Detailed description for the current settings of the node-RED instance
+

--- a/docs/api/admin/methods/get/flows/state/index.md
+++ b/docs/api/admin/methods/get/flows/state/index.md
@@ -1,0 +1,39 @@
+---
+layout: docs-api
+toc: toc-api-admin.html
+title: GET /flows/state
+slug:
+  - url: "/docs/api/admin"
+    label: "admin"
+  - url: "/docs/api/admin/methods"
+    label: "methods"
+  - get flows state
+---
+
+Get the current runtime state of flows. Note that runtime state of flows is available only if
+`runtimeState` value is set to `enabled: true` in the `settings.js` file.
+
+### Headers
+
+Header | Value
+-------|-------
+`Authorization` | `Bearer [token]` - if authentication is enabled
+
+### Response
+
+Status Code | Reason         | Response
+------------|----------------|--------------
+`200`       | Success        | See example response body
+`401`       | Not authorized | _none_
+
+{% highlight json %}
+{
+    "state": "stop"
+}
+{% endhighlight %}
+
+The response object contains the following fields:
+
+Field          | Description
+---------------|------------
+`state`        | runtime state of the flows. Can be either `start` or `stop`

--- a/docs/api/admin/methods/index.md
+++ b/docs/api/admin/methods/index.md
@@ -15,6 +15,7 @@ slug:
 [<span class="method">POST</span>/auth/token](post/auth/token)             | Exchange credentials for access token
 [<span class="method">POST</span>/auth/revoke](post/auth/revoke)           | Revoke an access token
 [<span class="method">GET</span>/settings](get/settings)                   | Get the runtime settings
+[<span class="method">GET</span>/diagnostics](get/diagnostics)                   | Get the runtime diagnostics
 [<span class="method">GET</span>/flows](get/flows)                         | Get the active flow configuration
 [<span class="method">POST</span>/flows](post/flows)                       | Set the active flow configuration
 [<span class="method">POST</span>/flow](post/flow)                         | Add a flow to the active configuration

--- a/docs/api/admin/methods/index.md
+++ b/docs/api/admin/methods/index.md
@@ -15,9 +15,11 @@ slug:
 [<span class="method">POST</span>/auth/token](post/auth/token)             | Exchange credentials for access token
 [<span class="method">POST</span>/auth/revoke](post/auth/revoke)           | Revoke an access token
 [<span class="method">GET</span>/settings](get/settings)                   | Get the runtime settings
-[<span class="method">GET</span>/diagnostics](get/diagnostics)                   | Get the runtime diagnostics
+[<span class="method">GET</span>/diagnostics](get/diagnostics)             | Get the runtime diagnostics
 [<span class="method">GET</span>/flows](get/flows)                         | Get the active flow configuration
+[<span class="method">GET</span>/flows/state](get/flows/state)             | Get the active flow's runtime state
 [<span class="method">POST</span>/flows](post/flows)                       | Set the active flow configuration
+[<span class="method">POST</span>/flows/state](post/flows/state)           | Set the active flow's runtime state
 [<span class="method">POST</span>/flow](post/flow)                         | Add a flow to the active configuration
 [<span class="method">GET</span>/flow/:id](get/flow)                       | Get an individual flow configuration
 [<span class="method">PUT</span>/flow/:id](put/flow)                       | Update an individual flow configuration

--- a/docs/api/admin/methods/post/flows/state/index.md
+++ b/docs/api/admin/methods/post/flows/state/index.md
@@ -1,0 +1,51 @@
+---
+layout: docs-api
+toc: toc-api-admin.html
+title: POST /flows/state
+slug:
+  - url: "/docs/api/admin"
+    label: "admin"
+  - url: "/docs/api/admin/methods"
+    label: "methods"
+  - set flows state
+---
+
+Set the runtime state of flows. Note that runtime state of flows is available only if
+`runtimeState` value is set to `enabled: true` in the `settings.js` file.
+
+Requires permission: <code>flows.write</code>
+
+### Headers
+
+Header | Value
+-------|-------
+`Authorization` | `Bearer [token]` - if authentication is enabled
+
+
+### Arguments
+
+The request body must be a URL-Encoded parameter with the following field:
+
+
+Field        | Description
+-------------|------------------------
+`state`      | Required runtime state of the flow. Can be either `start` or `stop` 
+
+### Response
+
+Status Code | Reason         | Response
+------------|----------------|--------------
+`200`       | Success        | See example response body
+`401`       | Not authorized | _none_
+
+{% highlight json %}
+{
+    "state": "stop"
+}
+{% endhighlight %}
+
+The response object contains the following fields:
+
+Field          | Description
+---------------|------------
+`state`        | runtime state of the flows. Can be either `start` or `stop`


### PR DESCRIPTION
This PR closes #301, closes #303  by documenting the following:

## `/diagnostics` Endpoint

- Keep structure of documentation similar to `/settings`.
- Add a note that `/diagnostics` endpoint is available only when `settings.js` has `diagnostics` option enabled
- add the `GET /diagnostics` endpoint in the API table

## `/flows/state` Endpoint

- Add API documentation for HTTP GET /flows/state
- Add API documentation for HTTP POST /flows/state

Signed-off-by: Shantanoo 'Shan' Desai <shantanoo.desai@gmail.com>