### PR TITLE
[Docs] Add link to logging API in logging section

### DIFF
--- a/docs/user-guide/runtime/logging.md
+++ b/docs/user-guide/runtime/logging.md
@@ -50,6 +50,7 @@ Level of logging to be recorded. Options are:
 
 Other than `off`, each level includes messages at higher levels - for example, `warn` level
 will include `error` and `fatal` level messages.
+You can find the API reference for how to log to these different logging levels in the [Writing Functions Section](/docs/user-guide/writing-functions#node)
 
 #### `metrics`
 


### PR DESCRIPTION
I had a hard time finding the API for logging as only the [Logging](https://nodered.org/docs/user-guide/runtime/logging) section came up when I googled terms such as "node red logging". My hope is that this change will prevent others from having the same difficulty as me.