### PR TITLE
Replace PNG icon with SVG icon in node development document

### DIFF
--- a/docs/creating-nodes/appearance.md
+++ b/docs/creating-nodes/appearance.md
@@ -27,7 +27,7 @@ a node instance, as well as for the node's entry in the palette. In this latter 
 
 {% highlight javascript %}
 ...
-icon: "file.png",
+icon: "file.svg",
 ...
 {% endhighlight %}
 

--- a/docs/creating-nodes/first-node.md
+++ b/docs/creating-nodes/first-node.md
@@ -116,9 +116,9 @@ For more information about the runtime part of the node, see [here](node-js).
         defaults: {
             name: {value:""}
         },
-        inputs:1,
-        outputs:1,
-        icon: "file.png",
+        inputs: 1,
+        outputs: 1,
+        icon: "file.svg",
         label: function() {
             return this.name||"lower-case";
         }


### PR DESCRIPTION
From Node-RED v1.0, the core icons are changed to SVG format. The PNG icon definitions still work, but I thought that the sample code should have an SVG icon in case node developers develop the new node from the official document and extend the functionality.