### PR TITLE
Update user-guide/writing-functions.md: adding missing close square bracket

### DIFF
--- a/docs/user-guide/writing-functions.md
+++ b/docs/user-guide/writing-functions.md
@@ -337,7 +337,7 @@ flow.get(["count", "colour"], function(err, count, colour) { ... })
 flow.set("count", 123, function(err) { ... })
 
 // Set multiple values
-flow.set(["count", "colour", [123, "red"], function(err) { ... })
+flow.set(["count", "colour"], [123, "red"], function(err) { ... })
 {% endhighlight %}
 
 The first argument passed to the callback, `err`, is only set if an error


### PR DESCRIPTION
there is a bracket missing in multiple flow context set call