### PR TITLE
Update website URLs of Hitachi members

### DIFF
--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -35,12 +35,12 @@
     - name: Kazuhito Yokoi
       githubId: '20310935'
       links:
-        home: https://hitachi.com
+        home: https://www.hitachi-ac.co.jp/en/
         github: https://github.com/kazuhitoyokoi
     - name: Hiroyasu Nishiyama
       githubId: '30289092'
       links:
-        home: https://hitachi.com
+        home: https://www.hitachi.com
         github: https://github.com/HiroyasuNishiyama
     - name: Mauricio Bonani
       githubId: '29807944'


### PR DESCRIPTION
Thank you for posting our profiles on the Node-RED website. However, the URLs for the corporate websites are invalid. Therefore, I corrected them in this pull request.