### PR TITLE
Remove "Survey banner"

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -43,8 +43,9 @@
 </head>
 <body>
 <div class="banner">
-	<div><a href="https://nrcon.nodered.org" class="banner-content">📆 Node-RED Con - 4th November 2025 &raquo;</a></div>
-	<div><a href="https://survey.nodered.org" class="banner-content">📋 Help Shape the Future of Node-RED - Complete the Survey &raquo;</a></div>
+	<a href="https://nrcon.nodered.org" class="banner-content">
+		Node-RED Con - 4th November 2025 &raquo;
+	</a>
 </div>
 <div class="header">
     <div class="header-content">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -44,7 +44,7 @@
 <body>
 <div class="banner">
 	<a href="https://nrcon.nodered.org" class="banner-content">
-		Node-RED Con - 4th November 2025 &raquo;
+		📆 Node-RED Con - 4th November 2025 &raquo;
 	</a>
 </div>
 <div class="header">


### PR DESCRIPTION
Reverts node-red/node-red.github.io#387 now that the survey has closed, the survey callout banner is no longer necessary.