### PR TITLE
fix: icon prop can be a function

### DIFF
--- a/docs/creating-nodes/node-html.md
+++ b/docs/creating-nodes/node-html.md
@@ -60,7 +60,7 @@ editor. It is an object with the following properties:
 - `labelStyle`: (string\|function) the [style](appearance#label-style) to apply to the label.
 - `inputLabels`: (string\|function) optional [label](appearance#port-labels) to add on hover to the input port of a node.
 - `outputLabels`: (string\|function) optional [labels](appearance#port-labels) to add on hover to the output ports of a node.
-- `icon`: (string) the [icon](appearance#icon) to use.
+- `icon`: (string\|function) the [icon](appearance#icon) to use.
 - `align`: (string) the [alignment](appearance#alignment) of the icon and label.
 - `button`: (object) adds a [button](appearance#buttons) to the edge of the node.
 - `oneditprepare`: (function) called when the edit dialog is being built. See [custom edit behaviour](properties#custom-edit-behaviour).


### PR DESCRIPTION
the icon prop can also be a function that returns a string according to https://nodered.org/docs/creating-nodes/appearance#icon