### PR TITLE
docs: clarify nodesDir accepts an array of paths

### DIFF
--- a/docs/user-guide/runtime/configuration.md
+++ b/docs/user-guide/runtime/configuration.md
@@ -26,10 +26,11 @@ userDir
   library data. Default: `$HOME/.node-red`
 
 nodesDir
-: a directory to search for additional installed nodes. Node-RED searches the `nodes`
-  directory under the *userDir* directory. This property allows an additional directory
-  to be searched, so that nodes can be installed outside of the Node-RED install
-  structure. Default: `$HOME/.node-red/nodes`
+: one or more directories to search for additional installed nodes, given as either a
+  single string or an array of strings. Node-RED searches the `nodes` directory under
+  the *userDir* directory. This property allows additional directories to be searched,
+  so that nodes can be installed outside of the Node-RED install structure.
+  Default: `$HOME/.node-red/nodes`
 
 uiHost
 : the interface to listen for connections on. Default: `0.0.0.0` -


### PR DESCRIPTION
## Related issue
node-red/node-red#1131

## What changed
The `nodesDir` entry in the configuration reference only said "a directory", but the runtime has accepted an array of paths since `0b8e8de2` (0.7.0, April 2014) — verified in `localfilesystem.js` (node-red/node-red), which normalizes the setting with:

```js
nodesDir = Array.isArray(settings.nodesDir) ? settings.nodesDir : [settings.nodesDir]
```

This was the second of the two spots the issue points at. Companion fix to the `settings.js` comment: node-red/node-red#5925.

🤖 Generated with [Claude Code](https://claude.com/claude-code)